### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout-land/activity_main_menu.xml
+++ b/app/src/main/res/layout-land/activity_main_menu.xml
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout android:id="@+id/drawer_layout_main"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    android:fitsSystemWindows="true"
-    tools:openDrawer="start"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<?xml version='1.0' encoding='utf-8'?>
+  <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/drawer_layout_main"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  android:fitsSystemWindows="true"
+  tools:openDrawer="start">
 
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+  <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fitsSystemWindows="true"
@@ -17,155 +16,139 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/appbar"
+    <android.support.design.widget.AppBarLayout android:id="@+id/appbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:theme="@style/AppTheme.AppBarOverlay">
+
+      <android.support.v7.widget.Toolbar android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
-
-        <android.support.v7.widget.Toolbar
-             android:id="@+id/toolbar"
-             android:layout_width="match_parent"
-             android:layout_height="?attr/actionBarSize"
-             android:background="?attr/colorPrimary"
-             app:popupTheme="@style/AppTheme.PopupOverlay">
-
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/AppTheme.PopupOverlay">
+        
         </android.support.v7.widget.Toolbar>
-
-
     </android.support.design.widget.AppBarLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:weightSum="2"
-            android:id="@+id/main_content"
-            android:orientation="horizontal"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:weightSum="2"
+      android:id="@+id/main_content"
+      android:orientation="horizontal"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-            <RelativeLayout
-                android:layout_width="0px"
-                android:layout_height="match_parent"
-                android:layoutDirection="ltr"
-                android:layout_weight="1">
-
-                <android.support.v4.view.ViewPager
-                    android:id="@+id/scroller"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-                <ImageView
-                    android:id="@+id/arrow_left"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/ic_keyboard_arrow_left_black_24dp"
-                    android:layout_alignParentLeft="true"
-                    android:layout_alignParentStart="true"
-                    android:padding="@dimen/activity_horizontal_margin"
-                    android:layout_marginStart="@dimen/activity_horizontal_margin"
-                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                    android:layout_centerVertical="true"
-                    android:onClick="onClick"/>
-                <ImageView
-                    android:id="@+id/arrow_right"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/activity_horizontal_margin"
-                    android:src="@drawable/ic_keyboard_arrow_right_black_24dp"
-                    android:layout_alignParentRight="true"
-                    android:layout_alignParentEnd="true"
-                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                    android:layout_marginRight="@dimen/activity_horizontal_margin"
-                    android:layout_centerVertical="true"
-                    android:onClick="onClick"/>
-            </RelativeLayout>
-
-            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_below="@+id/scroller"
-                android:layout_weight="1"
-                android:paddingLeft="@dimen/activity_horizontal_margin"
-                android:paddingRight="@dimen/activity_horizontal_margin"
-                android:paddingTop="@dimen/activity_vertical_margin"
-                android:paddingBottom="@dimen/activity_vertical_margin"
-                tools:context="tu_darmstadt.sudoku.ui.MainActivity"
-                android:orientation="vertical"
-                android:weightSum="0"
-                android:divider="#000"
-                android:baselineAligned="false"
-                android:gravity="center_horizontal">
-
-                <TextView
-                    android:id="@+id/difficultyText"
-                    android:layout_marginTop="@dimen/activity_vertical_margin"
-                    android:layout_height="wrap_content"
-                    android:layout_width="wrap_content"
-                    android:text="@string/difficulty_easy"
-                    android:textSize="@dimen/main_text_difficulty"/>
-
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/activity_vertical_margin"
-                    android:id="@+id/difficultyBar"
-                    android:layout_gravity="center_horizontal"
-                    android:clickable="true"
-                    android:numStars="3"
-                    android:rating="1"
-                    android:stepSize="1"
-                    style="@style/RatingBar"/>
-
-                <Button
-                    android:textColor="@color/white"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
-                    android:layout_marginLeft="40dp"
-                    android:layout_marginRight="40dp"
-                    android:text="@string/new_game"
-                    android:textStyle="normal"
-                    android:textSize="@dimen/text_size"
-                    android:id="@+id/playButton"
-                    android:layout_gravity="center_horizontal"
-                    android:onClick="onClick"
-                    android:capitalize="none"
-                    android:clickable="false"
-                    android:elevation="10dp"
-                    android:background="@drawable/standalone_button"/>
-
-                <Button
-                    android:textColor="@color/white"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/activity_vertical_margin"
-                    android:layout_marginLeft="40dp"
-                    android:layout_marginRight="40dp"
-                    android:text="@string/menu_continue_game"
-                    android:textStyle="normal"
-                    android:textSize="@dimen/text_size"
-                    android:id="@+id/continueButton"
-                    android:layout_gravity="center_horizontal"
-                    android:onClick="onClick"
-                    android:capitalize="none"
-                    android:clickable="true"
-                    android:background="@drawable/standalone_button"/>
-
-        </LinearLayout>
-
-   </LinearLayout>
-
-</android.support.design.widget.CoordinatorLayout>
-    <android.support.design.widget.NavigationView
-        android:id="@+id/nav_view_main"
-        android:layout_width="wrap_content"
+      <RelativeLayout android:layout_width="0px"
         android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:fitsSystemWindows="true"
-        android:background="@color/white"
-        app:menu="@menu/menu_drawer_main"
-        app:headerLayout="@layout/nav_header" />
+        android:layoutDirection="ltr"
+        android:layout_weight="1">
 
+        <android.support.v4.view.ViewPager android:id="@+id/scroller"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+        <ImageView android:id="@+id/arrow_left"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:src="@drawable/ic_keyboard_arrow_left_black_24dp"
+          android:layout_alignParentLeft="true"
+          android:layout_alignParentStart="true"
+          android:padding="@dimen/activity_horizontal_margin"
+          android:layout_marginStart="@dimen/activity_horizontal_margin"
+          android:layout_marginLeft="@dimen/activity_horizontal_margin"
+          android:layout_centerVertical="true"
+          android:onClick="onClick"/>
+
+        <ImageView android:id="@+id/arrow_right"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:padding="@dimen/activity_horizontal_margin"
+          android:src="@drawable/ic_keyboard_arrow_right_black_24dp"
+          android:layout_alignParentRight="true"
+          android:layout_alignParentEnd="true"
+          android:layout_marginEnd="@dimen/activity_horizontal_margin"
+          android:layout_marginRight="@dimen/activity_horizontal_margin"
+          android:layout_centerVertical="true"
+          android:onClick="onClick"/>
+      </RelativeLayout>
+
+      <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        tools:context="tu_darmstadt.sudoku.ui.MainActivity"
+        android:orientation="vertical"
+        android:weightSum="0"
+        android:divider="#000"
+        android:baselineAligned="false"
+        android:gravity="center_horizontal">
+
+        <TextView android:id="@+id/difficultyText"
+          android:layout_marginTop="@dimen/activity_vertical_margin"
+          android:layout_height="wrap_content"
+          android:layout_width="wrap_content"
+          android:text="@string/difficulty_easy"
+          android:textSize="@dimen/main_text_difficulty"/>
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/activity_vertical_margin"
+          android:id="@+id/difficultyBar"
+          android:layout_gravity="center_horizontal"
+          android:clickable="true"
+          android:numStars="3"
+          android:rating="1"
+          android:stepSize="1"
+          style="@style/RatingBar"/>
+
+        <Button android:textColor="@color/white"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="20dp"
+          android:layout_marginLeft="40dp"
+          android:layout_marginRight="40dp"
+          android:text="@string/new_game"
+          android:textStyle="normal"
+          android:textSize="@dimen/text_size"
+          android:id="@+id/playButton"
+          android:layout_gravity="center_horizontal"
+          android:onClick="onClick"
+          android:capitalize="none"
+          android:clickable="false"
+          android:elevation="10dp"
+          android:background="@drawable/standalone_button"/>
+
+        <Button android:textColor="@color/white"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="@dimen/activity_vertical_margin"
+          android:layout_marginLeft="40dp"
+          android:layout_marginRight="40dp"
+          android:text="@string/menu_continue_game"
+          android:textStyle="normal"
+          android:textSize="@dimen/text_size"
+          android:id="@+id/continueButton"
+          android:layout_gravity="center_horizontal"
+          android:onClick="onClick"
+          android:capitalize="none"
+          android:clickable="true"
+          android:background="@drawable/standalone_button"/>
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+      </LinearLayout>
+    </LinearLayout>
+  </android.support.design.widget.CoordinatorLayout>
+
+  <android.support.design.widget.NavigationView android:id="@+id/nav_view_main"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:fitsSystemWindows="true"
+    android:background="@color/white"
+    app:menu="@menu/menu_drawer_main"
+    app:headerLayout="@layout/nav_header"/>
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout-land/fragment_stats.xml
+++ b/app/src/main/res/layout-land/fragment_stats.xml
@@ -1,332 +1,317 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:weightSum="5"
-    android:orientation="vertical"
-    tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:weightSum="5"
+  android:orientation="vertical"
+  tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0px"
-        android:layout_weight="1"
-        android:orientation="horizontal"
-        android:gravity="center"
-        android:weightSum="3">
-            <LinearLayout
-                android:layout_width="0px"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:text="@string/number_of_hints"
-                    android:layout_weight="1"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:text="0"
-                    android:id="@+id/numb_of_hints"
-                    android:layout_weight="1"/>
-            </LinearLayout>
-        <LinearLayout
-            android:layout_width="0px"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-        <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_games"
-                android:layout_weight="1"/>
-            </LinearLayout>
-        <LinearLayout
-            android:layout_width="0px"
-            android:layout_weight="1"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/total_of_time"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_time"
-                android:layout_weight="1"/>
-            </LinearLayout>
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0px"
+    android:layout_weight="1"
+    android:orientation="horizontal"
+    android:gravity="center"
+    android:weightSum="3">
+
+    <LinearLayout android:layout_width="0px"
+      android:layout_weight="1"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_hints"
+        android:layout_weight="1"/>
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="fill_parent"
+    <LinearLayout android:layout_width="0px"
+      android:layout_weight="1"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_games"
+        android:layout_weight="1"/>
+    </LinearLayout>
+
+    <LinearLayout android:layout_width="0px"
+      android:layout_weight="1"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/total_of_time"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_time"
+        android:layout_weight="1"/>
+    </LinearLayout>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="0.5">
+
+    <View android:layout_width="match_parent"
+      android:layout_height="2dp"
+      android:layout_gravity="center_vertical"
+      android:foregroundGravity="center_vertical"
+      android:background="@color/colorPrimary">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+      <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+    </View>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="match_parent"
+    android:layout_height="0px"
+    android:layout_weight="3.5"
+    android:weightSum="9"
+    android:orientation="horizontal">
+
+    <ImageView android:layout_weight="3"
+      android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"
+      android:id="@+id/statistic_image"
+      android:src="@drawable/icon_default_9x9"
+      android:adjustViewBounds="true"/>
+
+    <RelativeLayout android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="1">
+
+      <View android:layout_width="2dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:foregroundGravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorPrimary"
+        android:layout_marginTop="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+    </RelativeLayout>
+
+    <LinearLayout android:layout_width="0px"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:layout_weight="5.5"
+      android:weightSum="3">
+      <!-- ### first row -->
+
+      <LinearLayout android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="0.5">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_gravity="center_vertical"
-            android:foregroundGravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_centerHorizontal="true"
-            android:background="@color/colorPrimary" />
+        android:layout_weight="1"
+        android:weightSum="3">
 
-    </LinearLayout>
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0px"
-        android:layout_weight="3.5"
-        android:weightSum="9"
-        android:orientation="horizontal">
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
 
-
-        <ImageView
-            android:layout_weight="3"
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
+          <RatingBar android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:numStars="3"
             android:layout_gravity="center"
-            android:id="@+id/statistic_image"
-            android:src="@drawable/icon_default_9x9"
-            android:adjustViewBounds="true"/>
-        <RelativeLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1">
-            <View
-                android:layout_width="2dp"
-                android:layout_height="match_parent"
-                android:layout_gravity="center_vertical"
-                android:foregroundGravity="center_vertical"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
-                android:background="@color/colorPrimary"
-                android:layout_marginTop="@dimen/activity_horizontal_margin"
-                android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+            android:id="@+id/first_diff_bar"
+            android:layout_below="@+id/first_diff_text"
+            style="?android:attr/ratingBarStyleSmall"/>
 
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="diffi"
+            android:id="@+id/first_diff_text"
+            android:gravity="center_vertical"/>
         </RelativeLayout>
 
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
 
-        <LinearLayout
-            android:layout_width="0px"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:layout_weight="5.5"
-            android:weightSum="3">
-            <!-- ### first row -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1"
-                android:weightSum="3">
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/first_diff_bar"
-                    android:layout_below="@+id/first_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/first_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/average_time"
+            android:id="@+id/first_av_text"/>
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/first_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_av_text"/>
-            </RelativeLayout>
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/first_ava_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/first_av_text"/>
+        </RelativeLayout>
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/first_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_min_text"/>
-            </RelativeLayout>
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
 
-        </LinearLayout>
-            <!-- ### second row -->
-            <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/min_time"
+            android:id="@+id/first_min_text"/>
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/second_diff_bar"
-                    android:layout_below="@+id/second_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/second_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/first_min_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/first_min_text"/>
+        </RelativeLayout>
+      </LinearLayout>
+      <!-- ### second row -->
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/second_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/second_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_min_text"/>
-            </RelativeLayout>
-        </LinearLayout>
-            <!-- ### third row -->
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1">
+      <LinearLayout android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:weightSum="3">
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/third_diff_bar"
-                    android:layout_below="@+id/third_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/third_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
 
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/third_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/third_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_min_text"/>
-            </RelativeLayout>
-        </LinearLayout>
-        </LinearLayout>
+          <RatingBar android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:numStars="3"
+            android:layout_gravity="center"
+            android:id="@+id/second_diff_bar"
+            android:layout_below="@+id/second_diff_text"
+            style="?android:attr/ratingBarStyleSmall"/>
 
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="diffi"
+            android:id="@+id/second_diff_text"
+            android:gravity="center_vertical"/>
+        </RelativeLayout>
 
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
 
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/average_time"
+            android:id="@+id/second_av_text"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/second_ava_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/second_av_text"/>
+        </RelativeLayout>
+
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/min_time"
+            android:id="@+id/second_min_text"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/second_min_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/second_min_text"/>
+        </RelativeLayout>
+      </LinearLayout>
+      <!-- ### third row -->
+
+      <LinearLayout android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
+
+          <RatingBar android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:numStars="3"
+            android:layout_gravity="center"
+            android:id="@+id/third_diff_bar"
+            android:layout_below="@+id/third_diff_text"
+            style="?android:attr/ratingBarStyleSmall"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="diffi"
+            android:id="@+id/third_diff_text"
+            android:gravity="center_vertical"/>
+        </RelativeLayout>
+
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/average_time"
+            android:id="@+id/third_av_text"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/third_ava_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/third_av_text"/>
+        </RelativeLayout>
+
+        <RelativeLayout android:layout_width="0dp"
+          android:layout_height="fill_parent"
+          android:layout_weight="1"
+          android:gravity="center_vertical">
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/min_time"
+            android:id="@+id/third_min_text"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="0"
+            android:id="@+id/third_min_time"
+            android:gravity="center_vertical"
+            android:layout_below="@+id/third_min_text"/>
+        </RelativeLayout>
+      </LinearLayout>
     </LinearLayout>
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout-xlarge-land/fragment_stats.xml
+++ b/app/src/main/res/layout-xlarge-land/fragment_stats.xml
@@ -1,316 +1,297 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:weightSum="10"
-    android:orientation="vertical"
-    tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:weightSum="10"
+  android:orientation="vertical"
+  tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="5">
-        <ImageView
-            android:layout_weight="2"
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:layout_gravity="center"
-            android:id="@+id/statistic_image"
-            android:src="@drawable/icon_default_9x9"
-            android:adjustViewBounds="true"/>
-        <RelativeLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1">
-            <View
-                android:layout_width="2dp"
-                android:layout_height="match_parent"
-                android:layout_gravity="center_vertical"
-                android:foregroundGravity="center_vertical"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
-                android:background="@color/colorPrimary"
-                android:layout_marginTop="@dimen/activity_horizontal_margin"
-                android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="5">
 
-        </RelativeLayout>
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:weightSum="6"
-            android:layout_weight="2"
-            android:orientation="vertical"
-            android:paddingTop="@dimen/activity_horizontal_margin">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/total_of_time"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_time"
-                android:layout_weight="1"/>
-        </LinearLayout>
+    <ImageView android:layout_weight="2"
+      android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"
+      android:id="@+id/statistic_image"
+      android:src="@drawable/icon_default_9x9"
+      android:adjustViewBounds="true"/>
+
+    <RelativeLayout android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="1">
+
+      <View android:layout_width="2dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:foregroundGravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorPrimary"
+        android:layout_marginTop="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+    </RelativeLayout>
+
+    <LinearLayout android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:weightSum="6"
+      android:layout_weight="2"
+      android:orientation="vertical"
+      android:paddingTop="@dimen/activity_horizontal_margin">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/total_of_time"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_time"
+        android:layout_weight="1"/>
+    </LinearLayout>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="1">
+
+    <View android:layout_width="match_parent"
+      android:layout_height="2dp"
+      android:layout_gravity="center_vertical"
+      android:foregroundGravity="center_vertical"
+      android:background="@color/colorPrimary">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+      <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+    </View>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="3"
+    android:orientation="vertical">
+    <!-- ### first row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/first_diff_bar"
+          android:layout_below="@+id/first_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/first_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/first_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/first_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_min_text"/>
+      </RelativeLayout>
+    </LinearLayout>
+    <!-- ### second row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/second_diff_bar"
+          android:layout_below="@+id/second_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/second_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/second_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/second_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_gravity="center_vertical"
-            android:foregroundGravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_centerHorizontal="true"
-            android:background="@color/colorPrimary" />
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1">
 
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/third_diff_bar"
+          android:layout_below="@+id/third_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/third_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/third_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/third_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="3"
-        android:orientation="vertical">
-        <!-- ### first row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/first_diff_bar"
-                    android:layout_below="@+id/first_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/first_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/first_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_av_text"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/first_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-        <!-- ### second row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/second_diff_bar"
-                    android:layout_below="@+id/second_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/second_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/second_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/second_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_min_text"/>
-            </RelativeLayout>
-        </LinearLayout>
-
-
-
-
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/third_diff_bar"
-                    android:layout_below="@+id/third_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/third_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/third_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/third_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-
-
-    </LinearLayout>
-
-
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout-xlarge/activity_main_menu.xml
+++ b/app/src/main/res/layout-xlarge/activity_main_menu.xml
@@ -1,15 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.DrawerLayout android:id="@+id/drawer_layout_main"
-    android:layout_height="match_parent"
-    android:layout_width="match_parent"
-    android:fitsSystemWindows="true"
-    tools:openDrawer="start"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<?xml version='1.0' encoding='utf-8'?>
+  <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:id="@+id/drawer_layout_main"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  android:fitsSystemWindows="true"
+  tools:openDrawer="start">
 
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+  <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fitsSystemWindows="true"
@@ -17,226 +16,272 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/appbar"
+    <android.support.design.widget.AppBarLayout android:id="@+id/appbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:theme="@style/AppTheme.AppBarOverlay">
+
+      <android.support.v7.widget.Toolbar android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
-
-        <android.support.v7.widget.Toolbar
-             android:id="@+id/toolbar"
-             android:layout_width="match_parent"
-             android:layout_height="?attr/actionBarSize"
-             android:background="?attr/colorPrimary"
-             app:popupTheme="@style/AppTheme.PopupOverlay">
-
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/AppTheme.PopupOverlay">
+        
         </android.support.v7.widget.Toolbar>
-
-
     </android.support.design.widget.AppBarLayout>
 
-   <LinearLayout
-        android:layout_height="match_parent"
+    <LinearLayout android:layout_height="match_parent"
+      android:layout_width="match_parent"
+      android:orientation="vertical"
+      android:weightSum="10"
+      android:id="@+id/main_content"
+      style="?android:buttonBarStyle"
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+      <RelativeLayout android:layout_width="fill_parent"
+        android:layout_height="0dp"
+        android:layoutDirection="ltr"
+        android:layout_weight="4">
+
+        <android.support.v4.view.ViewPager android:id="@+id/scroller"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
+
+        <ImageView android:id="@+id/arrow_left"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:src="@drawable/ic_keyboard_arrow_left_black_24dp"
+          android:layout_alignParentLeft="true"
+          android:layout_alignParentStart="true"
+          android:padding="@dimen/activity_horizontal_margin"
+          android:layout_marginStart="@dimen/activity_horizontal_margin"
+          android:layout_marginLeft="@dimen/activity_horizontal_margin"
+          android:layout_centerVertical="true"
+          android:onClick="onClick"/>
+
+        <ImageView android:id="@+id/arrow_right"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:src="@drawable/ic_keyboard_arrow_right_black_24dp"
+          android:layout_alignParentRight="true"
+          android:layout_alignParentEnd="true"
+          android:padding="@dimen/activity_horizontal_margin"
+          android:layout_marginEnd="@dimen/activity_horizontal_margin"
+          android:layout_marginRight="@dimen/activity_horizontal_margin"
+          android:layout_centerVertical="true"
+          android:onClick="onClick"/>
+      </RelativeLayout>
+
+      <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="6"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        tools:context="tu_darmstadt.sudoku.ui.MainActivity"
         android:orientation="vertical"
-        android:weightSum="10"
-       android:id="@+id/main_content"
-        style="?android:buttonBarStyle"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
-        <RelativeLayout
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            android:layoutDirection="ltr"
-            android:layout_weight="4">
+        android:weightSum="8"
+        android:divider="#000"
+        android:baselineAligned="false"
+        android:gravity="center_horizontal"
+        style="?android:buttonBarStyle">
 
-        <android.support.v4.view.ViewPager
-            android:id="@+id/scroller"
+        <TextView android:id="@+id/difficultyText"
+          android:layout_height="wrap_content"
+          android:layout_width="wrap_content"
+          android:text="@string/difficulty_easy"
+          android:textSize="@dimen/main_text_difficulty"/>
 
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:id="@+id/difficultyBar"
+          android:layout_gravity="center_horizontal"
+          android:clickable="true"
+          android:numStars="3"
+          android:rating="1"
+          android:padding="0dp"
+          android:layout_margin="0dp"
+          android:stepSize="1"
+          android:paddingTop="70dp"
+          style="@style/RatingBar"/>
 
-            <ImageView
-                android:id="@+id/arrow_left"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_left_black_24dp"
-                android:layout_alignParentLeft="true"
-                android:layout_alignParentStart="true"
-                android:padding="@dimen/activity_horizontal_margin"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_centerVertical="true"
-                android:onClick="onClick"/>
-            <ImageView
-                android:id="@+id/arrow_right"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_keyboard_arrow_right_black_24dp"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true"
-                android:padding="@dimen/activity_horizontal_margin"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:layout_centerVertical="true"
-                android:onClick="onClick"/>
-        </RelativeLayout>
+        <Button android:textColor="@color/white"
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:layout_marginTop="@dimen/activity_vertical_margin"
+          android:layout_marginLeft="@dimen/main_button_padding"
+          android:layout_marginRight="@dimen/main_button_padding"
+          android:text="@string/new_game"
+          android:textStyle="normal"
+          android:textSize="@dimen/text_size"
+          android:id="@+id/playButton"
+          android:layout_gravity="center_horizontal"
+          android:layout_weight="2"
+          android:onClick="onClick"
+          android:capitalize="none"
+          android:clickable="false"
+          android:elevation="10dp"
+          android:background="@drawable/standalone_button"/>
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_below="@id/scroller"
-            android:layout_weight="6"
-            android:paddingLeft="@dimen/activity_horizontal_margin"
-            android:paddingRight="@dimen/activity_horizontal_margin"
-            android:paddingTop="@dimen/activity_vertical_margin"
-            android:paddingBottom="@dimen/activity_vertical_margin"
-            tools:context="tu_darmstadt.sudoku.ui.MainActivity"
-            android:orientation="vertical"
-            android:weightSum="8"
-            android:divider="#000"
-            android:baselineAligned="false"
-            android:gravity="center_horizontal"
-            style="?android:buttonBarStyle">
+        <Button android:textColor="@color/white"
+          android:layout_marginTop="20dp"
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:layout_marginLeft="@dimen/main_button_padding"
+          android:layout_marginRight="@dimen/main_button_padding"
+          android:text="@string/menu_continue_game"
+          android:textStyle="normal"
+          android:textSize="@dimen/text_size"
+          android:id="@+id/continueButton"
+          android:layout_gravity="center_horizontal"
+          android:layout_weight="2"
+          android:onClick="onClick"
+          android:capitalize="none"
+          android:clickable="false"
+          android:background="@drawable/standalone_button"/>
+        <!--
 
-            <TextView
-                android:id="@+id/difficultyText"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                android:text="@string/difficulty_easy"
-                android:textSize="@dimen/main_text_difficulty"/>
-
-            <RatingBar
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:id="@+id/difficultyBar"
-                android:layout_gravity="center_horizontal"
-                android:clickable="true"
-                android:numStars="3"
-                android:rating="1"
-                android:padding="0dp"
-                android:layout_margin="0dp"
-                android:stepSize="1"
-                android:paddingTop="70dp"
-                style="@style/RatingBar"/>
-
-            <Button
-                android:textColor="@color/white"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_marginTop="@dimen/activity_vertical_margin"
-                android:layout_marginLeft="@dimen/main_button_padding"
-                android:layout_marginRight="@dimen/main_button_padding"
-                android:text="@string/new_game"
-                android:textStyle="normal"
-                android:textSize="@dimen/text_size"
-                android:id="@+id/playButton"
-                android:layout_gravity="center_horizontal"
-                android:layout_weight="2"
-                android:onClick="onClick"
-                android:capitalize="none"
-                android:clickable="false"
-                android:elevation="10dp"
-                android:background="@drawable/standalone_button"/>
-
-            <Button
-                android:textColor="@color/white"
-                android:layout_marginTop="20dp"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_marginLeft="@dimen/main_button_padding"
-                android:layout_marginRight="@dimen/main_button_padding"
-                android:text="@string/menu_continue_game"
-                android:textStyle="normal"
-                android:textSize="@dimen/text_size"
-                android:id="@+id/continueButton"
-                android:layout_gravity="center_horizontal"
-                android:layout_weight="2"
-                android:onClick="onClick"
-                android:capitalize="none"
-                android:clickable="false"
-                android:background="@drawable/standalone_button"/>
-<!--
             <LinearLayout
+
                 android:layout_width="match_parent"
+
                 android:layout_height="0dp"
+
                 android:layout_weight="2"
+
                 android:weightSum="2">
+
                 <Button
+
                     android:layout_width="0dp"
+
                     android:layout_height="match_parent"
+
                     android:layout_marginLeft="30dp"
+
                     android:layout_marginRight="1dp"
+
                     android:text="@string/menu_highscore"
+
                     android:textStyle="normal"
+
                     android:id="@+id/highscoreButton"
+
                     android:layout_gravity="center_horizontal"
+
                     android:layout_weight="1"
+
                     android:onClick="onClick"
+
                     android:capitalize="none"
+
                     android:clickable="false"/>
+
                 <Button
+
                     android:layout_width="0dp"
+
                     android:layout_height="match_parent"
+
                     android:layout_marginLeft="1dp"
+
                     android:layout_marginRight="30dp"
+
                     android:text="@string/menu_settings"
+
                     android:textStyle="normal"
+
                     android:id="@+id/settingsButton"
+
                     android:layout_gravity="center_horizontal"
+
                     android:layout_weight="1"
+
                     android:onClick="onClick"
+
                     android:capitalize="none"
+
                     android:clickable="false"/>
             </LinearLayout>
+
             <LinearLayout
+
                 android:layout_width="match_parent"
+
                 android:layout_height="0dp"
+
                 android:layout_weight="2"
+
                 android:weightSum="2">
+
                 <Button
+
                     android:layout_width="0dp"
+
                     android:layout_height="match_parent"
+
                     android:layout_marginLeft="30dp"
+
                     android:layout_marginRight="1dp"
+
                     android:text="@string/menu_about"
+
                     android:textStyle="normal"
+
                     android:id="@+id/aboutButton"
+
                     android:layout_gravity="center_horizontal"
+
                     android:layout_weight="1"
+
                     android:onClick="onClick"
+
                     android:capitalize="none"
+
                     android:clickable="false"/>
+
                 <Button
+
                     android:layout_width="0dp"
+
                     android:layout_height="match_parent"
+
                     android:layout_marginLeft="1dp"
+
                     android:layout_marginRight="30dp"
+
                     android:text="@string/menu_help"
+
                     android:textStyle="normal"
+
                     android:id="@+id/helpButton"
+
                     android:layout_gravity="center_horizontal"
+
                     android:layout_weight="1"
+
                     android:onClick="onClick"
+
                     android:capitalize="none"
+
                     android:clickable="false"/>
             </LinearLayout>
--->
-        </LinearLayout>
+              -->
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+      </LinearLayout>
+    </LinearLayout>
+  </android.support.design.widget.CoordinatorLayout>
 
-   </LinearLayout>
-
-</android.support.design.widget.CoordinatorLayout>
-
-    <android.support.design.widget.NavigationView
-        android:id="@+id/nav_view_main"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:fitsSystemWindows="true"
-        android:background="@color/white"
-        app:menu="@menu/menu_drawer_main"
-        app:headerLayout="@layout/nav_header" />
-
+  <android.support.design.widget.NavigationView android:id="@+id/nav_view_main"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:fitsSystemWindows="true"
+    android:background="@color/white"
+    app:menu="@menu/menu_drawer_main"
+    app:headerLayout="@layout/nav_header"/>
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout-xlarge/fragment_stats.xml
+++ b/app/src/main/res/layout-xlarge/fragment_stats.xml
@@ -1,316 +1,297 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:weightSum="10"
-    android:orientation="vertical"
-    tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:weightSum="10"
+  android:orientation="vertical"
+  tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="5">
-        <ImageView
-            android:layout_weight="2"
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:layout_gravity="center"
-            android:id="@+id/statistic_image"
-            android:src="@drawable/icon_default_9x9"
-            android:adjustViewBounds="true"/>
-        <RelativeLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1">
-            <View
-                android:layout_width="2dp"
-                android:layout_height="match_parent"
-                android:layout_gravity="center_vertical"
-                android:foregroundGravity="center_vertical"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
-                android:background="@color/colorPrimary"
-                android:layout_marginTop="@dimen/activity_horizontal_margin"
-                android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="5">
 
-        </RelativeLayout>
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:weightSum="6"
-            android:layout_weight="2"
-            android:orientation="vertical"
-            android:paddingTop="@dimen/activity_horizontal_margin">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/total_of_time"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_time"
-                android:layout_weight="1"/>
-        </LinearLayout>
+    <ImageView android:layout_weight="2"
+      android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"
+      android:id="@+id/statistic_image"
+      android:src="@drawable/icon_default_9x9"
+      android:adjustViewBounds="true"/>
+
+    <RelativeLayout android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="1">
+
+      <View android:layout_width="2dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:foregroundGravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorPrimary"
+        android:layout_marginTop="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+    </RelativeLayout>
+
+    <LinearLayout android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:weightSum="6"
+      android:layout_weight="2"
+      android:orientation="vertical"
+      android:paddingTop="@dimen/activity_horizontal_margin">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/total_of_time"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_time"
+        android:layout_weight="1"/>
+    </LinearLayout>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="1">
+
+    <View android:layout_width="match_parent"
+      android:layout_height="2dp"
+      android:layout_gravity="center_vertical"
+      android:foregroundGravity="center_vertical"
+      android:background="@color/colorPrimary">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+      <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+    </View>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="3"
+    android:orientation="vertical">
+    <!-- ### first row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/first_diff_bar"
+          android:layout_below="@+id/first_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/first_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/first_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/first_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_min_text"/>
+      </RelativeLayout>
+    </LinearLayout>
+    <!-- ### second row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/second_diff_bar"
+          android:layout_below="@+id/second_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/second_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/second_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/second_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_gravity="center_vertical"
-            android:foregroundGravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_centerHorizontal="true"
-            android:background="@color/colorPrimary" />
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1">
 
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/third_diff_bar"
+          android:layout_below="@+id/third_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/third_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/third_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/third_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="3"
-        android:orientation="vertical">
-        <!-- ### first row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/first_diff_bar"
-                    android:layout_below="@+id/first_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/first_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/first_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_av_text"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/first_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-        <!-- ### second row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/second_diff_bar"
-                    android:layout_below="@+id/second_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/second_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/second_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/second_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_min_text"/>
-            </RelativeLayout>
-        </LinearLayout>
-
-
-
-
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/third_diff_bar"
-                    android:layout_below="@+id/third_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/third_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/third_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/third_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-
-
-    </LinearLayout>
-
-
+  </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_main_menu.xml
+++ b/app/src/main/res/layout/fragment_main_menu.xml
@@ -1,31 +1,31 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:gravity="center_horizontal|center_vertical"
-    android:orientation="vertical"
-    android:weightSum="8"
-    tools:context="tu_darmstadt.sudoku.ui.MainActivity$GameTypeFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:gravity="center_horizontal|center_vertical"
+  android:orientation="vertical"
+  android:weightSum="8"
+  tools:context="tu_darmstadt.sudoku.ui.MainActivity$GameTypeFragment">
 
-    <TextView android:id="@+id/section_label"
-        android:text="Label"
-        android:textStyle="bold"
-        android:textSize="20dp"
-        android:layout_weight="1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+  <TextView android:id="@+id/section_label"
+    android:text="Label"
+    android:textStyle="bold"
+    android:textSize="20dp"
+    android:layout_weight="1"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"/>
 
-    <ImageView
-        android:layout_weight="5"
-        android:id="@+id/gameTypeImage"
-        android:layout_width="wrap_content"
-        android:adjustViewBounds="true"
-        android:layout_centerInParent="true"
-        android:src="@drawable/icon_default_9x9"
-        android:layout_height="0dp" />
-
+  <ImageView android:layout_weight="5"
+    android:id="@+id/gameTypeImage"
+    android:layout_width="wrap_content"
+    android:adjustViewBounds="true"
+    android:src="@drawable/icon_default_9x9"
+    android:layout_height="0dp">
+    <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+  </ImageView>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_stats.xml
+++ b/app/src/main/res/layout/fragment_stats.xml
@@ -1,316 +1,297 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:weightSum="10"
-    android:orientation="vertical"
-    tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
+<?xml version='1.0' encoding='UTF-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  android:weightSum="10"
+  android:orientation="vertical"
+  tools:context="tu_darmstadt.sudoku.ui.StatsActivity$PlaceholderFragment">
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="5">
-        <ImageView
-            android:layout_weight="2"
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:layout_gravity="center"
-            android:id="@+id/statistic_image"
-            android:src="@drawable/icon_default_9x9"
-            android:adjustViewBounds="true"/>
-        <RelativeLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1">
-            <View
-                android:layout_width="2dp"
-                android:layout_height="match_parent"
-                android:layout_gravity="center_vertical"
-                android:foregroundGravity="center_vertical"
-                android:layout_centerVertical="true"
-                android:layout_centerHorizontal="true"
-                android:background="@color/colorPrimary"
-                android:layout_marginTop="@dimen/activity_horizontal_margin"
-                android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="5">
 
-        </RelativeLayout>
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="fill_parent"
-            android:weightSum="6"
-            android:layout_weight="2"
-            android:orientation="vertical"
-            android:paddingTop="@dimen/activity_horizontal_margin">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_hints"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/number_of_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_games"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="@string/total_of_time"
-                android:layout_weight="1"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0"
-                android:id="@+id/numb_of_total_time"
-                android:layout_weight="1"/>
-        </LinearLayout>
+    <ImageView android:layout_weight="2"
+      android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:layout_gravity="center"
+      android:id="@+id/statistic_image"
+      android:src="@drawable/icon_default_9x9"
+      android:adjustViewBounds="true"/>
+
+    <RelativeLayout android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="1">
+
+      <View android:layout_width="2dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_vertical"
+        android:foregroundGravity="center_vertical"
+        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/colorPrimary"
+        android:layout_marginTop="@dimen/activity_horizontal_margin"
+        android:layout_marginBottom="@dimen/activity_horizontal_margin"/>
+    </RelativeLayout>
+
+    <LinearLayout android:layout_width="0dp"
+      android:layout_height="fill_parent"
+      android:weightSum="6"
+      android:layout_weight="2"
+      android:orientation="vertical"
+      android:paddingTop="@dimen/activity_horizontal_margin">
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_hints"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/number_of_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_games"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/total_of_time"
+        android:layout_weight="1"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="0"
+        android:id="@+id/numb_of_total_time"
+        android:layout_weight="1"/>
+    </LinearLayout>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="1">
+
+    <View android:layout_width="match_parent"
+      android:layout_height="2dp"
+      android:layout_gravity="center_vertical"
+      android:foregroundGravity="center_vertical"
+      android:background="@color/colorPrimary">
+      <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+      <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+    </View>
+  </LinearLayout>
+
+  <LinearLayout android:layout_width="fill_parent"
+    android:layout_height="0dp"
+    android:layout_weight="4"
+    android:weightSum="3"
+    android:orientation="vertical">
+    <!-- ### first row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/first_diff_bar"
+          android:layout_below="@+id/first_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/first_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/first_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/first_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/first_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/first_min_text"/>
+      </RelativeLayout>
+    </LinearLayout>
+    <!-- ### second row -->
+
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1"
+      android:weightSum="3">
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/second_diff_bar"
+          android:layout_below="@+id/second_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/second_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/second_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/second_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/second_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/second_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="2dp"
-            android:layout_gravity="center_vertical"
-            android:foregroundGravity="center_vertical"
-            android:layout_centerVertical="true"
-            android:layout_centerHorizontal="true"
-            android:background="@color/colorPrimary" />
+    <LinearLayout android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:layout_weight="1">
 
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <RatingBar android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:numStars="3"
+          android:layout_gravity="center"
+          android:id="@+id/third_diff_bar"
+          android:layout_below="@+id/third_diff_text"
+          style="?android:attr/ratingBarStyleSmall"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="diffi"
+          android:id="@+id/third_diff_text"
+          android:gravity="center_vertical"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/average_time"
+          android:id="@+id/third_av_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_ava_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_av_text"/>
+      </RelativeLayout>
+
+      <RelativeLayout android:layout_width="0dp"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:gravity="center_vertical">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/min_time"
+          android:id="@+id/third_min_text"/>
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="0"
+          android:id="@+id/third_min_time"
+          android:gravity="center_vertical"
+          android:layout_below="@+id/third_min_text"/>
+      </RelativeLayout>
     </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="0dp"
-        android:layout_weight="4"
-        android:weightSum="3"
-        android:orientation="vertical">
-        <!-- ### first row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/first_diff_bar"
-                    android:layout_below="@+id/first_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/first_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/first_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_av_text"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/first_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/first_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/first_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-        <!-- ### second row -->
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:weightSum="3">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/second_diff_bar"
-                    android:layout_below="@+id/second_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/second_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/second_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/second_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/second_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/second_min_text"/>
-            </RelativeLayout>
-        </LinearLayout>
-
-
-
-
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1">
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <RatingBar
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:numStars="3"
-                    android:layout_gravity="center"
-                    android:id="@+id/third_diff_bar"
-                    android:layout_below="@+id/third_diff_text"
-                    style="?android:attr/ratingBarStyleSmall"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="diffi"
-                    android:id="@+id/third_diff_text"
-                    android:gravity="center_vertical"/>
-            </RelativeLayout>
-
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/average_time"
-                    android:id="@+id/third_av_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_ava_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_av_text"/>
-            </RelativeLayout>
-            <RelativeLayout
-                android:layout_width="0dp"
-                android:layout_height="fill_parent"
-                android:layout_weight="1"
-                android:gravity="center_vertical">
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/min_time"
-                    android:id="@+id/third_min_text"/>
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="0"
-                    android:id="@+id/third_min_time"
-                    android:gravity="center_vertical"
-                    android:layout_below="@+id/third_min_text"/>
-            </RelativeLayout>
-
-        </LinearLayout>
-
-
-    </LinearLayout>
-
-
+  </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Hi (again),

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis