### PR TITLE
Getting correct value of "gameSolved" key (Partial fix for Issue #37)

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlysudoku/ui/GameActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlysudoku/ui/GameActivity.java
@@ -306,7 +306,7 @@ public class GameActivity extends BaseActivity implements NavigationView.OnNavig
                 finish();
                 overridePendingTransition(0, 0);
             }
-            gameSolved = savedInstanceState.getInt("gameSolved") == 1;
+            gameSolved = savedInstanceState.getBoolean("gameSolved");
         }
 
 


### PR DESCRIPTION
Observation:
1. savedInstanceState.getInt("gameSolved") ALWAYS returned 0 (default).
2. The key "gameSolved" is set with putBoolean, which is correct. A ClassCastException was thrown in getInt and the catch block returned the default 0-value.

Issues before change:
1. Multiple statements that are supposed to be executed based on gameSolved (like disabling the special keys and the sudoku grid), were skipped.
2. Because of that, after finishing a game, if someone changed the screen orientation, the keys and the grid became active again and the grid could be modified.

Changes done:
1. Changed it to getBoolean("gameSolved")
2. Removed the " == 1" part because that is redundant for a boolean.