### PR TITLE
Use human-readable relative times in LoadGameActivity.

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlysudoku/ui/LoadGameActivity.java
+++ b/app/src/main/java/org/secuso/privacyfriendlysudoku/ui/LoadGameActivity.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.text.format.DateUtils;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -260,12 +261,11 @@ public class LoadGameActivity extends BaseActivity implements IDeleteDialogFragm
             h = (hours< 10)? "0"+String.valueOf(hours):String.valueOf(hours);
             playedTime.setText(h + ":" + m + ":" + s);
 
-            Date lastTimePlayedDate = gic.getLastTimePlayed();
-
-            DateFormat format = DateFormat.getDateTimeInstance();
-            format.setTimeZone(TimeZone.getDefault());
-
-            lastTimePlayed.setText(format.format(lastTimePlayedDate));
+            long now = System.currentTimeMillis();
+            long lastTimePlayedTimestamp = gic.getLastTimePlayed().getTime();
+            CharSequence humanReadableRelativeTime = DateUtils.getRelativeTimeSpanString(
+                    lastTimePlayedTimestamp, now, DateUtils.MINUTE_IN_MILLIS);
+            lastTimePlayed.setText(humanReadableRelativeTime);
 
             return convertView;
         }


### PR DESCRIPTION
When loading a saved game, display the last time played in human readable relative time. For example, "5 minutes ago" or "Yesterday". This matches the template from list_entry_layout.xml

The current implementation writes the date in full, including day, month, year, hours, minutes, and seconds. Not only is that more
information than we really need, but in devices with a narrower screen this can cause the date to be drawn on top of the difficulty.

![sudoku-bug](https://user-images.githubusercontent.com/1452192/99911127-0ba3c000-2cd1-11eb-9cee-a600b8d80d57.png)
