### PR TITLE
#131 Restore input error highlighting after redo

### DIFF
--- a/app/src/main/java/org/secuso/privacyfriendlysudoku/controller/GameController.java
+++ b/app/src/main/java/org/secuso/privacyfriendlysudoku/controller/GameController.java
@@ -287,6 +287,26 @@ public class GameController implements IModelChangedListener, Parcelable {
     }
 
 
+    /**
+     * Rebuilds the conflict list from the current state of the whole board.
+     * This is needed whenever cells are written without going through
+     * {@link #setValue(int, int, int)}, because only that method feeds
+     * {@link #checkInputError(int, int)} with the cells that changed.
+     */
+    private void rebuildErrorList() {
+        if(settings == null || !settings.getBoolean("pref_highlightInputError", true)) {
+            return;
+        }
+
+        if (errorList == null) {
+            errorList = new CellConflictList();
+        }
+
+        // isSolved() clears the list and refills it with every conflict on the board
+        gameBoard.isSolved(errorList);
+    }
+
+
     private CellConflictList checkInputErrorList(GameCell cell, List<GameCell> list) {
         CellConflictList errorList = new CellConflictList();
         for (int i = 0; i < list.size(); i++) {
@@ -799,6 +819,10 @@ public class GameController implements IModelChangedListener, Parcelable {
                 }
             }
         }
+
+        // the cells above were written directly, so the conflicts of the
+        // restored board have to be determined again
+        rebuildErrorList();
 
         notifyHighlightChangedListeners();
         return;

--- a/app/src/test/java/org/secuso/privacyfriendlysudoku/controller/FakeSharedPreferences.java
+++ b/app/src/test/java/org/secuso/privacyfriendlysudoku/controller/FakeSharedPreferences.java
@@ -1,0 +1,99 @@
+/*
+ This file is part of Privacy Friendly Sudoku.
+
+ Privacy Friendly Sudoku is free software:
+ you can redistribute it and/or modify it under the terms of the
+ GNU General Public License as published by the Free Software Foundation,
+ either version 3 of the License, or any later version.
+
+ Privacy Friendly Sudoku is distributed in the hope
+ that it will be useful, but WITHOUT ANY WARRANTY; without even
+ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Privacy Friendly Sudoku. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.secuso.privacyfriendlysudoku.controller;
+
+import android.content.SharedPreferences;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * In-memory {@link SharedPreferences} for local unit tests, so that settings
+ * dependent behaviour of the {@link GameController} can be tested without an
+ * Android runtime. Only the getters are supported; everything that would
+ * require a real preference file throws.
+ */
+public class FakeSharedPreferences implements SharedPreferences {
+
+    private final Map<String, Object> values = new HashMap<>();
+
+    public FakeSharedPreferences put(String key, Object value) {
+        values.put(key, value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T get(String key, T defValue) {
+        return values.containsKey(key) ? (T) values.get(key) : defValue;
+    }
+
+    @Override
+    public Map<String, ?> getAll() {
+        return new HashMap<>(values);
+    }
+
+    @Override
+    public String getString(String key, String defValue) {
+        return get(key, defValue);
+    }
+
+    @Override
+    public Set<String> getStringSet(String key, Set<String> defValues) {
+        return get(key, defValues);
+    }
+
+    @Override
+    public int getInt(String key, int defValue) {
+        return get(key, defValue);
+    }
+
+    @Override
+    public long getLong(String key, long defValue) {
+        return get(key, defValue);
+    }
+
+    @Override
+    public float getFloat(String key, float defValue) {
+        return get(key, defValue);
+    }
+
+    @Override
+    public boolean getBoolean(String key, boolean defValue) {
+        return get(key, defValue);
+    }
+
+    @Override
+    public boolean contains(String key) {
+        return values.containsKey(key);
+    }
+
+    @Override
+    public Editor edit() {
+        throw new UnsupportedOperationException("FakeSharedPreferences is read only.");
+    }
+
+    @Override
+    public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        // no listeners in tests
+    }
+
+    @Override
+    public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+        // no listeners in tests
+    }
+}

--- a/app/src/test/java/org/secuso/privacyfriendlysudoku/controller/GameControllerTest.java
+++ b/app/src/test/java/org/secuso/privacyfriendlysudoku/controller/GameControllerTest.java
@@ -234,4 +234,36 @@ public class GameControllerTest {
         assertEquals(1, controller.getSelectedCol());
         assertEquals(0, controller.getSelectedRow());
     }
+
+    @Test
+    public void errorListIsRestoredOnRedoTest() {
+        controller.setSettings(new FakeSharedPreferences().put("pref_highlightInputError", true));
+
+        // a 5 on (1|2) collides with the fixed 5 on (0|0) and the fixed 5 on (1|7)
+        controller.selectCell(1, 2);
+        controller.selectValue(5);
+        assertEquals(2, controller.getErrorList().size());
+
+        controller.UnDo();
+        assertEquals(0, controller.getValue(1, 2));
+        assertEquals(0, controller.getErrorList().size());
+
+        controller.ReDo();
+        assertEquals(5, controller.getValue(1, 2));
+        assertEquals(2, controller.getErrorList().size());
+    }
+
+    @Test
+    public void errorListStaysEmptyOnRedoIfHighlightingIsDisabledTest() {
+        controller.setSettings(new FakeSharedPreferences().put("pref_highlightInputError", false));
+
+        controller.selectCell(1, 2);
+        controller.selectValue(5);
+        assertEquals(0, controller.getErrorList().size());
+
+        controller.UnDo();
+        controller.ReDo();
+        assertEquals(5, controller.getValue(1, 2));
+        assertEquals(0, controller.getErrorList().size());
+    }
 }


### PR DESCRIPTION
Fixes #131

**Observation**

Entering a digit that collides with another cell highlights both cells. Pressing `Undo` removes the digit, but pressing `Redo` brings the wrong digit back *without* the warning. The highlighting stays gone until the next manual input.

**Cause**

The conflict list is only ever filled by `setValue()`, which `UnDo()` and `ReDo()` bypass: both write the restored values straight into the cells through `updateGameBoard()`. `checkErrorList()` removes the conflicts of the undone input, but nothing adds them back on redo.

**Changes done**

1. `updateGameBoard()` now rebuilds the conflict list from the restored board. `GameBoard.isSolved()` already collects every conflict of a board, so it is reused instead of re-checking the changed cells one by one.
2. The rebuild is skipped when `pref_highlightInputError` is disabled, because `SudokuFieldLayout` draws the conflict list unconditionally.

**Tests**

Two unit tests were added to `GameControllerTest`, covering undo/redo with the setting enabled and disabled. The first one fails without the change. They need a `SharedPreferences` instance, so a small in-memory `FakeSharedPreferences` was added to the test sources — no new dependency and no Android runtime required, it can also be reused for other settings dependent tests.

`./gradlew test` passes. I also checked it manually on a device: entering a conflicting digit, then Undo, then Redo brings the circles and the connecting lines back.

Only the sudoku rules are consulted, never the solution, so nothing is revealed about the correct value.

I have read the contribution guidelines, including the "Unwanted Changes" section: Privacy. This change adds no libraries, no permissions, no network access and no tracking.
